### PR TITLE
Fixed uses annotation

### DIFF
--- a/EHPTexamples/package.mo
+++ b/EHPTexamples/package.mo
@@ -1,5 +1,5 @@
 package EHPTexamples "Package containing basic EV models"
 
   annotation (
-    uses(Modelica(version = "4.0.0"), EHPTlib(version = "2.1")));
+    uses(Modelica(version = "4.0.0"), EHPTlib(version = "2.1.4")));
 end EHPTexamples;


### PR DESCRIPTION
Only version 2.1.4 of EHPTlib is available on the package manager, so if we don't use that, you break the whole OSMC testing infrastructure.

See email.